### PR TITLE
ImageFilterView 를 구현하지 않고 넘어갑니다. Pod 를 설치했습니다.

### DIFF
--- a/Collageuner/Collageuner/CodesSaved/BingCodes.swift
+++ b/Collageuner/Collageuner/CodesSaved/BingCodes.swift
@@ -148,3 +148,79 @@ class ViewController: UIViewController {
 
 
 */
+
+
+/*   ⚠️ USAGE
+ let thumbnailSize = CGSize(width: 80, height: 80)
+ let scaledImage = image.scalePreservingAspectRatio(targetSize: thumbnailSize)
+ 
+ ...
+ 
+ guard let thumbnailImageData = scaledImage.pngData() else {
+ print("Failed to Compress Image into thumbnail Image")
+ return
+ }
+ */
+
+/// We'll be using OpenCV... So... but We can study the codes though.
+/// ⚠️ Code that smoothing Edges Failed, and none of them works fine....
+//    func smoothed(withRadius radius: CGFloat) -> UIImage? {
+//        let imageRect = CGRect(origin: .zero, size: size)
+//        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+//        defer { UIGraphicsEndImageContext() }
+//        guard let context = UIGraphicsGetCurrentContext() else { return nil }
+//        context.scaleBy(x: 1, y: -1)
+//        context.translateBy(x: 0, y: -size.height)
+//        context.setBlendMode(.normal)
+//        let rectPath = UIBezierPath(roundedRect: imageRect.insetBy(dx: radius, dy: radius), cornerRadius: radius)
+//        rectPath.addClip()
+//        draw(in: imageRect)
+//        context.drawLinearGradient(CGGradient(colorsSpace: nil, colors: [UIColor.clear.cgColor, UIColor.black.cgColor] as CFArray, locations: [0, 1])!, start: CGPoint(x: 0, y: size.height - radius), end: CGPoint(x: 0, y: size.height), options: []
+//        )
+//        let smoothedImage = UIGraphicsGetImageFromCurrentImageContext()
+//        return smoothedImage
+//    }
+
+//func smoothing() {
+//    let path = UIBezierPath(roundedRect: selectedImageView.bounds, cornerRadius: 20)
+//    let maskLayer = CAShapeLayer()
+//    maskLayer.path = path.cgPath
+//    selectedImageView.layer.mask = maskLayer
+//}
+//
+//func putFeatherEffect(image: UIImage?, radius: CGFloat) -> UIImage? {
+//    guard let inputImage = image else {
+//        print("🧷 1")
+//        return UIImage() }
+//    let context = CIContext()
+//    guard let ciImage = CIImage(image: inputImage) else {
+//        print("🧷 2")
+//        return UIImage()}
+//    guard let filter = CIFilter(name: "CIGaussianBlur") else {
+//        print("🧷 3")
+//        return UIImage()}
+//    filter.setValue(ciImage, forKey: kCIInputImageKey)
+//    filter.setValue(radius, forKey: kCIInputRadiusKey)
+//    guard let outputCiImage = filter.outputImage else {
+//        print("🧷 4")
+//        return UIImage()}
+//
+//    let mask = CIImage(color: CIColor(red: 1, green: 1, blue: 1, alpha: 0))
+//    guard let maskFilter = CIFilter(name: "CIRadialGradient") else {
+//        print("🧷 5")
+//        return UIImage()}
+//    maskFilter.setValue(CIVector(x: inputImage.size.width/2, y: inputImage.size.height/2), forKey: "inputCenter")
+//    maskFilter.setValue(inputImage.size.width/2 * 0.9, forKey: "inputRadius0")
+//    maskFilter.setValue(inputImage.size.width/2 * 1.1, forKey: "inputRadius1")
+//    let maskOutputCIImage = maskFilter.outputImage!.cropped(to: ciImage.extent)
+//
+//    let invertedMask = maskOutputCIImage.applyingFilter("CIColorInvert")
+//
+//    let maskedOutputCIImage = outputCiImage.applyingFilter("CIBlendWithMask", parameters: [kCIInputMaskImageKey: invertedMask])
+//
+//
+//    let cgImage = context.createCGImage(maskedOutputCIImage, from: maskedOutputCIImage.extent)!
+//    let outputImage = UIImage(cgImage: cgImage)
+//
+//    return outputImage
+//}

--- a/Collageuner/Collageuner/Extensions/UIImage+Extensions.swift
+++ b/Collageuner/Collageuner/Extensions/UIImage+Extensions.swift
@@ -36,25 +36,12 @@ extension UIImage {
     
     // Use it when resizing Image, especially for resizing UIBarButtonItem
     func resizeImage(size: CGSize) -> UIImage {
-      let originalSize = self.size
-      let ratio: CGFloat = {
-          return originalSize.width > originalSize.height ? 1 / (size.width / originalSize.width) :
-                                                            1 / (size.height / originalSize.height)
-      }()
-
-      return UIImage(cgImage: self.cgImage!, scale: self.scale * ratio, orientation: self.imageOrientation)
+        let originalSize = self.size
+        let ratio: CGFloat = {
+            return originalSize.width > originalSize.height ? 1 / (size.width / originalSize.width) :
+            1 / (size.height / originalSize.height)
+        }()
+        
+        return UIImage(cgImage: self.cgImage!, scale: self.scale * ratio, orientation: self.imageOrientation)
     }
 }
-
-
-/*   ⚠️ USAGE
-     let thumbnailSize = CGSize(width: 80, height: 80)
-     let scaledImage = image.scalePreservingAspectRatio(targetSize: thumbnailSize)
- 
-     ...
- 
-     guard let thumbnailImageData = scaledImage.pngData() else {
-         print("Failed to Compress Image into thumbnail Image")
-         return
-     }
- */

--- a/Collageuner/Podfile
+++ b/Collageuner/Podfile
@@ -1,0 +1,19 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'Collageuner' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for Collageuner
+
+  target 'CollageunerTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+  target 'CollageunerUITests' do
+    # Pods for testing
+  end
+
+end


### PR DESCRIPTION
## 📍 배경
- 네이티브 코드를 통해 누끼가 따진 이미지의 outline 에 feather와 smooth 효과를 주고 싶었지만, 구현이 힘들다고 판단했습니다.
- OpenCV 를 쓰는 방법을 생각했는데, CocoaPods 를 사용해야하고 Object-C 를 활용해야 하기 때문에 공수가 아주 크게 든다고 생각이 들었습니다. 그래서 해당 필터의 경우, 마지막으로 순서를 빼서 아마 Pre-Launch(UT) 때, 업데이트를 할 것 같습니다.

## 🪜 작업 내용 (Content)
- Pod 를 설치했습니다.
